### PR TITLE
[WIP] Remove Singletons

### DIFF
--- a/PowerScout/AppDelegate.swift
+++ b/PowerScout/AppDelegate.swift
@@ -13,6 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     var window: UIWindow?
     var orientationLock: UIInterfaceOrientationMask = .all
+    var matchStore = MatchStore()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -23,8 +24,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
             } else {
                 navigationController.topViewController!.navigationItem.leftBarButtonItem = nil
             }
-            splitViewController.delegate = self
             
+            let masterNC = splitViewController.viewControllers[0] as! UINavigationController
+            if let masterVC = masterNC.topViewController as? MasterViewController {
+                masterVC.matchStore = matchStore
+            }
+            
+            splitViewController.delegate = self
         }
         
         return true

--- a/PowerScout/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/PowerScout/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/PowerScout/Models/MatchStore.swift
+++ b/PowerScout/Models/MatchStore.swift
@@ -9,9 +9,6 @@
 import UIKit
 
 class MatchStore: Any {
-    
-    static let sharedStore:MatchStore = MatchStore()
-    
     var allMatches:[Match] = []
     var matchesToScout:[MatchQueueData] = []
     var currentMatchIndex = -1


### PR DESCRIPTION
## Problem

The current app depends on a couple of singleton instances to manage data. While this is a well known pattern that is easy to use, it complicates debugging and introduces tightly coupled code that can't easily be unit tested. 

## Solution

Remove the singleton instances and instead define a top level variable that gets injected to all dependents. This doesn't affect the usage of the instance (only one still gets used), but this allows the object to be mocked for unit tests and ensures a loose coupling between the store and view controllers. 

## Issues Fixed
Resolves #15 

## Checks
- [x] App Builds and Runs
- [x] Normal functionality still exists