### PR TITLE
Remove Coupling of MatchEncodingHelper

### DIFF
--- a/PowerScout/Models/Match.swift
+++ b/PowerScout/Models/Match.swift
@@ -48,7 +48,7 @@ protocol Match : CsvDataProvider, MatchCoding {
     var finalComments:String   { get set }
     
     // Calculated Variables
-    var messageDictionary:Dictionary<String, AnyObject> { get }
+    var messageDictionary:[String:AnyObject] { get }
     
     init(queueData:MatchQueueData)
     
@@ -57,7 +57,7 @@ protocol Match : CsvDataProvider, MatchCoding {
     func aggregateMatchData()
 }
 
-class MatchImpl : Any, Match {
+class MatchImpl : Match {
     
     // Team Info
     
@@ -97,7 +97,7 @@ class MatchImpl : Any, Match {
         return matchData;
     }
     
-    var messageDictionary:Dictionary<String, AnyObject> {
+    var messageDictionary: [String:AnyObject] {
         var data:[String:AnyObject]    = [String:AnyObject]()
         var team:[String:AnyObject]    = [String:AnyObject]()
         var final:[String:AnyObject]   = [String:AnyObject]()

--- a/PowerScout/Models/MatchEncodingHelper.swift
+++ b/PowerScout/Models/MatchEncodingHelper.swift
@@ -36,48 +36,22 @@ class MatchEncodingHelper : NSObject, NSCoding {
         
         // convert dictionary to match here
         match = MatchImpl(withPList: pList)
-        
         super.init()
     }
     
     func encode(with aCoder: NSCoder) {
-        guard let pList = try? propertyListRepresentation() else {
-            return
+        guard let plistData = try? propertyListRepresentation() else {
+            return // Return early
         }
         
-        aCoder.encode(pList, forKey:"pListData")
+        aCoder.encode(plistData, forKey:"pListData")
     }
     
     func propertyListRepresentation() throws -> [String:AnyObject] {
-        var data = [String:AnyObject]()
-        var team = [String:AnyObject]()
-        var final = [String:AnyObject]()
-        
         guard let m = match else {
             throw MatchEncodingError.NoMatchData
         }
         
-        // Team Info
-        team["teamNumber"]  = m.teamNumber           as AnyObject?
-        team["matchNumber"] = m.matchNumber          as AnyObject?
-        team["alliance"]    = m.alliance.rawValue    as AnyObject?
-        team["isCompleted"] = m.isCompleted          as AnyObject?
-        
-        // Final Info
-        final["score"]      = m.finalScore           as AnyObject?
-        final["rPoints"]    = m.finalRankingPoints   as AnyObject?
-        final["result"]     = m.finalResult.rawValue as AnyObject?
-        final["pScore"]     = m.finalPenaltyScore    as AnyObject?
-        final["fouls"]      = m.finalFouls           as AnyObject?
-        final["tFouls"]     = m.finalTechFouls       as AnyObject?
-        final["yCards"]     = m.finalYellowCards     as AnyObject?
-        final["rCards"]     = m.finalRedCards        as AnyObject?
-        final["robot"]      = m.finalRobot.rawValue  as AnyObject?
-        final["comments"]   = m.finalComments        as AnyObject?
-        
-        data["team"]        = team                   as AnyObject?
-        data["final"]       = final                  as AnyObject?
-        
-        return data;
+        return m.messageDictionary
     }
 }


### PR DESCRIPTION
## Problem

The problem is well-defined in #21 . The `MatchEncodingHelper` introduces an unnecessary indirect coupling to `Match`. 

## Solution

Remove coupling. `MatchEncodingHelper` will now correctly function for all `Match`es and subclasses, so no subclass of `MatchEncodingHelper` needs to be defined.

## Issues Fixed
Resolve #21 
