### PR TITLE
Add PowerMatch Data Structure

### DIFF
--- a/PowerScout.xcodeproj/project.pbxproj
+++ b/PowerScout.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		C481787220132531001EAF24 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C481787020132531001EAF24 /* LaunchScreen.storyboard */; };
 		C481787D20132531001EAF24 /* PowerScoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481787C20132531001EAF24 /* PowerScoutTests.swift */; };
 		C481788820132531001EAF24 /* PowerScoutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481788720132531001EAF24 /* PowerScoutUITests.swift */; };
+		C4BF77A8202927C3006C34CC /* PowerMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77A7202927C3006C34CC /* PowerMatch.swift */; };
+		C4BF77AA20292817006C34CC /* PowerStartPositionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77A920292817006C34CC /* PowerStartPositionType.swift */; };
+		C4BF77AC2029284F006C34CC /* PowerEndClimbPositionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +92,9 @@
 		C481788320132531001EAF24 /* PowerScoutUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PowerScoutUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C481788720132531001EAF24 /* PowerScoutUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerScoutUITests.swift; sourceTree = "<group>"; };
 		C481788920132531001EAF24 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C4BF77A7202927C3006C34CC /* PowerMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerMatch.swift; sourceTree = "<group>"; };
+		C4BF77A920292817006C34CC /* PowerStartPositionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerStartPositionType.swift; sourceTree = "<group>"; };
+		C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerEndClimbPositionType.swift; sourceTree = "<group>"; };
 		E2D24E694F4F9F710E5EE5C5 /* Pods_PowerScout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PowerScout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA393782602B7CFAE85CDBEE /* Pods-PowerScout.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PowerScout.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PowerScout/Pods-PowerScout.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -181,6 +187,7 @@
 				C40BB9732013E7C60011DB45 /* MatchStore.swift */,
 				C40BB9772013E7C60011DB45 /* SteamMatch.swift */,
 				C40BB9782013E7C60011DB45 /* StrongMatch.swift */,
+				C4BF77A7202927C3006C34CC /* PowerMatch.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -190,6 +197,8 @@
 			children = (
 				C40BB96C2013E7C60011DB45 /* SteamGearPlacementType.swift */,
 				C40BB96D2013E7C60011DB45 /* SteamStartPositionType.swift */,
+				C4BF77A920292817006C34CC /* PowerStartPositionType.swift */,
+				C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */,
 			);
 			path = Definitions;
 			sourceTree = "<group>";
@@ -465,6 +474,8 @@
 				C40BB97A2013E7C60011DB45 /* SteamStartPositionType.swift in Sources */,
 				C40BB97B2013E7C60011DB45 /* Definitions.swift in Sources */,
 				C40BB9522013E7050011DB45 /* AppUtility.swift in Sources */,
+				C4BF77AC2029284F006C34CC /* PowerEndClimbPositionType.swift in Sources */,
+				C4BF77AA20292817006C34CC /* PowerStartPositionType.swift in Sources */,
 				C40BB9792013E7C60011DB45 /* SteamGearPlacementType.swift in Sources */,
 				C40BB9582013E7050011DB45 /* themeDefinitions.swift in Sources */,
 				C40BB9592013E7050011DB45 /* UINavigationController+Rotation.swift in Sources */,
@@ -474,6 +485,7 @@
 				C481786620132531001EAF24 /* AppDelegate.swift in Sources */,
 				C40BB9842013E7C60011DB45 /* SteamMatch.swift in Sources */,
 				C40BB97F2013E7C60011DB45 /* MatchEncodingHelper.swift in Sources */,
+				C4BF77A8202927C3006C34CC /* PowerMatch.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PowerScout/DetailControllers/DataEntryViewController.swift
+++ b/PowerScout/DetailControllers/DataEntryViewController.swift
@@ -33,19 +33,7 @@ class DataEntryViewController: UIViewController, UIPickerViewDataSource, UIPicke
     @IBOutlet weak var climbButton: UIButton!
     @IBOutlet weak var climbYN: UISegmentedControl!
     
-    var autoScaleBlock = 0
-    var autoScaleVar = 0
-    var autoSwitchVar = 0
-    var teleScaleVar = 0
-    var teleSwitchVar = 0
-    var exchangedBlocksVar = 0
-    var autoLineX = false
-    var scaleLowX = false
-    var scaleMediumX = false
-    var scaleHighX = false
-    var anyClimb = false
-    var startPosition = " "
-    var climbingCondition = " "
+    var match:PowerMatch!
     
     let startPositions = ["Exchange", "Center", "Non-Exchange"]
     let climbConditions = ["No attempt or failure to climb", "No climb but helped another", "Climb by themselves", "Climb with help", "Climb helping another team"]
@@ -78,10 +66,16 @@ class DataEntryViewController: UIViewController, UIPickerViewDataSource, UIPicke
         exchangedBlocks.maximumValue = 20
         exchangedBlocks.stepValue = 1
         super.viewDidLoad()
-        // Do any additional setup after loading the view
     }
     
-    //UIPickerView stuff (DON'T TOUCH OR SUFFER HELL) I speak from experiance
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        match = PowerMatch()
+    }
+    
+    // MARK: UIPickerView Functions
+    // UIPickerView stuff (DON'T TOUCH OR SUFFER HELL) I speak from experiance
     @IBAction func climbCondSelect(_ sender: UIButton) {
         if climbingConditionPick.isHidden {
             climbingConditionPick.isHidden = false
@@ -118,82 +112,60 @@ class DataEntryViewController: UIViewController, UIPickerViewDataSource, UIPicke
         if pickerview == startPositionPick{
             positionButton.setTitle(startPositions[row], for: .normal)
             startPositionPick.isHidden = true
-            startPosition = startPositions[row]
+            match.autoStartPos = PowerStartPositionType(rawValue: row+1)!
         }
         if pickerview == climbingConditionPick{
             climbButton.setTitle(climbConditions[row], for: .normal)
             climbingConditionPick.isHidden = true
-            climbingCondition = climbConditions[row]
+            match.endClimbCondition = PowerEndClimbPositionType(rawValue: row)!
         }
     }
     
-    @IBAction func scaleLow(_ sender: UISegmentedControl) {
-        if scaleLow.selectedSegmentIndex == 0{
-            scaleLowX = false
+    @IBAction func segmentedControlSelect(_ sender: UISegmentedControl) {
+        switch sender {
+        case autoLine:
+            match.autoCrossedLine = sender.selectedSegmentIndex == 1
+            break
+        case scaleLow:
+            match.teleLow = sender.selectedSegmentIndex == 1
+            break
+        case scaleMedium:
+            match.teleNormal = sender.selectedSegmentIndex == 1
+            break
+        case scaleHigh:
+            match.teleHigh = sender.selectedSegmentIndex == 1
+            break
+        default:
+            break
         }
-        if scaleLow.selectedSegmentIndex == 1{
-            scaleLowX = true
-        }
-        
-    }
-    @IBAction func autoLineCrossed(_ sender: UISegmentedControl) {
-        if autoLine.selectedSegmentIndex == 0{
-            autoLineX = false
-        }
-        if autoLine.selectedSegmentIndex == 1{
-            autoLineX = true
-        }
-        
-    }
-    @IBAction func scaleMedium(_ sender: UISegmentedControl) {
-        if scaleMedium.selectedSegmentIndex == 0{
-            scaleMediumX = false
-        }
-        if scaleMedium.selectedSegmentIndex == 1{
-            scaleMediumX = true
-        }
-    }
-    @IBAction func scaleHigh(_ sender: UISegmentedControl) {
-        if scaleHigh.selectedSegmentIndex == 0{
-            scaleHighX = false
-        }
-        if scaleHigh.selectedSegmentIndex == 1{
-            scaleHighX = true
-        }
-        
-    }
-   
-    @IBAction func climbYNSelected(_ sender: UISegmentedControl) {
-        if climbYN.selectedSegmentIndex == 0{
-             anyClimb = false
-        }
-        if climbYN.selectedSegmentIndex == 1{
-             anyClimb = true
-        }
-    }
- 
-    @IBAction func autoScaleValueChanged(_ sender: UIStepper) {
-        autoScaleBlock = Int(sender.value)
-        autoAmmountScale.text=Int(sender.value).description
     }
     
-    @IBAction func autoSwitchValueChanged(_ sender: UIStepper) {
-        autoSwitchVar = Int(sender.value)
-        autoAmmountSwitch.text=Int(sender.value).description
+    @IBAction func stepperValueChanged(_ sender: UIStepper) {
+        switch sender {
+        case autoScale:
+            match.autoScaleCubes = Int(sender.value)
+            autoAmmountScale.text = match.autoScaleCubes.description
+            break
+        case autoSwitch:
+            match.autoSwitchCubes = Int(sender.value)
+            autoAmmountSwitch.text = match.autoSwitchCubes.description
+            break
+        case teleScale:
+            match.teleScaleCubes = Int(sender.value)
+            teleAmmountScale.text = match.teleScaleCubes.description
+            break
+        case teleSwitch:
+            match.teleSwitchCubes = Int(sender.value)
+            teleAmmountSwitch.text = match.teleSwitchCubes.description
+            break
+        case exchangedBlocks:
+            match.teleExchangeCubes = Int(sender.value)
+            ammountExchangedBlocks.text = match.teleExchangeCubes.description
+            break
+        default:
+            break
+        }
     }
-    @IBAction func teleopScaleValueChanged(_ sender: UIStepper) {
-        teleScaleVar = Int(sender.value)
-        teleAmmountScale.text=Int(sender.value).description
-    }
-    @IBAction func teleopSwitchValueChanged(_ sender: UIStepper) {
-        teleSwitchVar = Int(sender.value)
-        teleAmmountSwitch.text=Int(sender.value).description
-    }
-    @IBAction func teleopBlockExchangedValueChanged(_ sender: UIStepper) {
-        exchangedBlocksVar = Int(sender.value)
-        ammountExchangedBlocks.text=Int(sender.value).description
-    }
-    
 }
 
     

--- a/PowerScout/Models/Definitions/PowerEndClimbPositionType.swift
+++ b/PowerScout/Models/Definitions/PowerEndClimbPositionType.swift
@@ -1,0 +1,17 @@
+//
+//  PowerEndClimbPositionType.swift
+//  PowerScout
+//
+//  Created by Srinivas Dhanwada on 2/5/18.
+//  Copyright © 2018 FRC Team 525. All rights reserved.
+//
+
+import Foundation
+
+enum PowerEndClimbPositionType: Int {
+    case none = 0
+    case assistOther
+    case soloClimb
+    case assistedClimb
+    case soloClimbAssistOther
+}

--- a/PowerScout/Models/Definitions/PowerStartPositionType.swift
+++ b/PowerScout/Models/Definitions/PowerStartPositionType.swift
@@ -1,0 +1,16 @@
+//
+//  PowerStartPositionType.swift
+//  PowerScout
+//
+//  Created by Srinivas Dhanwada on 2/5/18.
+//  Copyright © 2018 FRC Team 525. All rights reserved.
+//
+
+import Foundation
+
+enum PowerStartPositionType:Int {
+    case none = 0
+    case exchange
+    case center
+    case nonExchange
+}

--- a/PowerScout/Models/PowerMatch.swift
+++ b/PowerScout/Models/PowerMatch.swift
@@ -13,19 +13,18 @@ class PowerMatch : MatchImpl {
     // Auto Info
     var autoStartPos:PowerStartPositionType = .none
     var autoCrossedLine:Bool = false
-    var autoScaleBlocks:Int = 0
-    var autoSwitchBlocks:Int = 0
+    var autoScaleCubes:Int = 0
+    var autoSwitchCubes:Int = 0
     
     // Teleop Info
-    var teleScaleBlocks:Int = 0
-    var teleSwitchBlocks:Int = 0
-    var teleExchangeBlocks:Int = 0
+    var teleScaleCubes:Int = 0
+    var teleSwitchCubes:Int = 0
+    var teleExchangeCubes:Int = 0
     var teleLow:Bool = false
     var teleNormal:Bool =  false
     var teleHigh:Bool = false
     
     // End Game Info
-    var endClimb:Bool = false
     var endClimbCondition:PowerEndClimbPositionType = .none
     
     required init() {
@@ -44,19 +43,18 @@ class PowerMatch : MatchImpl {
         // Auto Info
         autoStartPos = PowerStartPositionType(rawValue: json["auto"]["startPos"].intValue)!
         autoCrossedLine = json["auto"]["crossed"].boolValue
-        autoScaleBlocks = json["auto"]["scale"].intValue
-        autoSwitchBlocks = json["auto"]["switch"].intValue
+        autoScaleCubes = json["auto"]["scale"].intValue
+        autoSwitchCubes = json["auto"]["switch"].intValue
         
         // Tele Info
-        teleScaleBlocks = json["tele"]["scale"].intValue
-        teleSwitchBlocks = json["tele"]["switch"].intValue
-        teleExchangeBlocks = json["tele"]["exchange"].intValue
+        teleScaleCubes = json["tele"]["scale"].intValue
+        teleSwitchCubes = json["tele"]["switch"].intValue
+        teleExchangeCubes = json["tele"]["exchange"].intValue
         teleLow = json["tele"]["low"].boolValue
         teleNormal = json["tele"]["normal"].boolValue
         teleHigh = json["tele"]["high"].boolValue
         
         // End Game Info
-        endClimb = json["endg"]["climb"].boolValue
         endClimbCondition = PowerEndClimbPositionType(rawValue: json["endg"]["climbCond"].intValue)!
     }
     
@@ -69,19 +67,18 @@ class PowerMatch : MatchImpl {
         // Auto Info
         auto["startPos"] = autoStartPos.rawValue as AnyObject?
         auto["crossed"] = autoCrossedLine as AnyObject?
-        auto["scale"] = autoScaleBlocks as AnyObject?
-        auto["switch"] = autoSwitchBlocks as AnyObject?
+        auto["scale"] = autoScaleCubes as AnyObject?
+        auto["switch"] = autoSwitchCubes as AnyObject?
         
         // Tele Info
-        tele["scale"] = teleScaleBlocks as AnyObject?
-        tele["switch"] = teleSwitchBlocks as AnyObject?
-        tele["exchange"] = teleExchangeBlocks as AnyObject?
+        tele["scale"] = teleScaleCubes as AnyObject?
+        tele["switch"] = teleSwitchCubes as AnyObject?
+        tele["exchange"] = teleExchangeCubes as AnyObject?
         tele["low"] = teleLow as AnyObject?
         tele["normal"] = teleNormal as AnyObject?
         tele["high"] = teleHigh as AnyObject?
         
         // End Game Info
-        endg["climb"] = endClimb as AnyObject?
         endg["climbCond"] = endClimbCondition.rawValue as AnyObject?
         
         data["auto"] = auto as AnyObject?
@@ -97,13 +94,13 @@ class PowerMatch : MatchImpl {
         matchHeader += "Match Number, Team Number, Alliance, "
         
         // Auto Info
-        matchHeader += "Auto Start Position, Auto Line Crossed, Auto Scale Blocks, Auto Switch Blocks, "
+        matchHeader += "Auto Start Position, Auto Line Crossed, Auto Scale Cubes, Auto Switch Cubes, "
         
         // Tele Info
-        matchHeader += "Tele Scale Blocks, Tele Switch Blocks, Tele Exchange Blocks, Tele Low, Tele Normal, Tele High, "
+        matchHeader += "Tele Scale Cubes, Tele Switch Cubes, Tele Exchange Cubes, Tele Low, Tele Normal, Tele High, "
         
         // End Game Info
-        matchHeader += "End Game Climb, End Game Climb Condition, "
+        matchHeader += "End Game Climb Condition, "
         
         // Final Info
         matchHeader += "Final Score, Final Ranking Points, Penalty Points Received, Final Result, Fouls, Tech Fouls, Yellow Cards, Red Cards, Robot, Config, Comments \r\n"
@@ -135,7 +132,6 @@ class PowerMatch : MatchImpl {
         matchData += "\(match["tele", "high"].boolValue), "
         
         // End Game Info
-        matchData += "\(match["endg", "climb"].boolValue), "
         matchData += "\(match["endg", "climbCond"].intValue), "
         
         // Final Info

--- a/PowerScout/Models/PowerMatch.swift
+++ b/PowerScout/Models/PowerMatch.swift
@@ -1,0 +1,164 @@
+//
+//  PowerMatch.swift
+//  PowerScout
+//
+//  Created by Srinivas Dhanwada on 2/5/18.
+//  Copyright © 2018 FRC Team 525. All rights reserved.
+//
+
+import Foundation
+import SwiftyJSON
+
+class PowerMatch : MatchImpl {
+    // Auto Info
+    var autoStartPos:PowerStartPositionType = .none
+    var autoCrossedLine:Bool = false
+    var autoScaleBlocks:Int = 0
+    var autoSwitchBlocks:Int = 0
+    
+    // Teleop Info
+    var teleScaleBlocks:Int = 0
+    var teleSwitchBlocks:Int = 0
+    var teleExchangeBlocks:Int = 0
+    var teleLow:Bool = false
+    var teleNormal:Bool =  false
+    var teleHigh:Bool = false
+    
+    // End Game Info
+    var endClimb:Bool = false
+    var endClimbCondition:PowerEndClimbPositionType = .none
+    
+    required init() {
+        super.init()
+    }
+    
+    required init(queueData: MatchQueueData) {
+        super.init(queueData: queueData)
+    }
+    
+    required init(withPList pList: [String : AnyObject]) {
+        super.init(withPList: pList)
+        
+        let json = JSON(pList)
+        
+        // Auto Info
+        autoStartPos = PowerStartPositionType(rawValue: json["auto"]["startPos"].intValue)!
+        autoCrossedLine = json["auto"]["crossed"].boolValue
+        autoScaleBlocks = json["auto"]["scale"].intValue
+        autoSwitchBlocks = json["auto"]["switch"].intValue
+        
+        // Tele Info
+        teleScaleBlocks = json["tele"]["scale"].intValue
+        teleSwitchBlocks = json["tele"]["switch"].intValue
+        teleExchangeBlocks = json["tele"]["exchange"].intValue
+        teleLow = json["tele"]["low"].boolValue
+        teleNormal = json["tele"]["normal"].boolValue
+        teleHigh = json["tele"]["high"].boolValue
+        
+        // End Game Info
+        endClimb = json["endg"]["climb"].boolValue
+        endClimbCondition = PowerEndClimbPositionType(rawValue: json["endg"]["climbCond"].intValue)!
+    }
+    
+    override var messageDictionary: [String : AnyObject] {
+        var data = super.messageDictionary
+        var auto = [String:AnyObject]()
+        var tele = [String:AnyObject]()
+        var endg = [String:AnyObject]()
+        
+        // Auto Info
+        auto["startPos"] = autoStartPos.rawValue as AnyObject?
+        auto["crossed"] = autoCrossedLine as AnyObject?
+        auto["scale"] = autoScaleBlocks as AnyObject?
+        auto["switch"] = autoSwitchBlocks as AnyObject?
+        
+        // Tele Info
+        tele["scale"] = teleScaleBlocks as AnyObject?
+        tele["switch"] = teleSwitchBlocks as AnyObject?
+        tele["exchange"] = teleExchangeBlocks as AnyObject?
+        tele["low"] = teleLow as AnyObject?
+        tele["normal"] = teleNormal as AnyObject?
+        tele["high"] = teleHigh as AnyObject?
+        
+        // End Game Info
+        endg["climb"] = endClimb as AnyObject?
+        endg["climbCond"] = endClimbCondition.rawValue as AnyObject?
+        
+        data["auto"] = auto as AnyObject?
+        data["tele"] = tele as AnyObject?
+        data["endg"] = endg as AnyObject?
+        
+        return data
+    }
+    
+    override class var csvHeader: String {
+        var matchHeader = ""
+        // Team Info
+        matchHeader += "Match Number, Team Number, Alliance, "
+        
+        // Auto Info
+        matchHeader += "Auto Start Position, Auto Line Crossed, Auto Scale Blocks, Auto Switch Blocks, "
+        
+        // Tele Info
+        matchHeader += "Tele Scale Blocks, Tele Switch Blocks, Tele Exchange Blocks, Tele Low, Tele Normal, Tele High, "
+        
+        // End Game Info
+        matchHeader += "End Game Climb, End Game Climb Condition, "
+        
+        // Final Info
+        matchHeader += "Final Score, Final Ranking Points, Penalty Points Received, Final Result, Fouls, Tech Fouls, Yellow Cards, Red Cards, Robot, Config, Comments \r\n"
+        
+        return matchHeader
+    }
+    
+    override var csvMatch: String {
+        var matchData = ""
+        let match = JSON(messageDictionary)
+        
+        // Team Info
+        matchData += "\(match["team", "matchNumber"].intValue), "
+        matchData += "\(match["team", "teamNumber"].intValue), "
+        matchData += "\(match["team", "alliance"].intValue), "
+        
+        // Auto Info
+        matchData += "\(match["auto", "startPos"].intValue), "
+        matchData += "\(match["auto", "crossed"].boolValue), "
+        matchData += "\(match["auto", "scale"].intValue), "
+        matchData += "\(match["auto", "switch"].intValue), "
+        
+        // Tele Info
+        matchData += "\(match["tele", "scale"].intValue), "
+        matchData += "\(match["tele", "switch"].intValue), "
+        matchData += "\(match["tele", "exchange"].intValue), "
+        matchData += "\(match["tele", "low"].boolValue), "
+        matchData += "\(match["tele", "normal"].boolValue), "
+        matchData += "\(match["tele", "high"].boolValue), "
+        
+        // End Game Info
+        matchData += "\(match["endg", "climb"].boolValue), "
+        matchData += "\(match["endg", "climbCond"].intValue), "
+        
+        // Final Info
+        matchData += "\(match["final", "score"].intValue),"
+        matchData += "\(match["final", "rPoints"].intValue),"
+        matchData += "\(match["final", "pScore"].intValue),"
+        matchData += "\(match["final", "result"].intValue),"
+        matchData += "\(match["final", "fouls"].intValue),"
+        matchData += "\(match["final", "tFouls"].intValue),"
+        matchData += "\(match["final", "yCards"].intValue),"
+        matchData += "\(match["final", "rCards"].intValue),"
+        matchData += "\(match["final", "robot"].intValue),"
+        matchData += "\(match["final", "config"].intValue),"
+        matchData += "\(match["final", "comments"].stringValue)"
+        
+        return matchData
+    }
+    
+    override func updateForType(_ type: UpdateType, withMatch match: Match) {
+        // Do Nothing
+    }
+    
+    override func aggregateMatchData() {
+        // Do Nothing
+    }
+}

--- a/PowerScout/Storyboards/Base.lproj/DataEntry.storyboard
+++ b/PowerScout/Storyboards/Base.lproj/DataEntry.storyboard
@@ -697,7 +697,7 @@
                                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ssU-XW-a6d">
                                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="29"/>
                                                                 <connections>
-                                                                    <action selector="autoScaleValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="j45-5o-a5b"/>
+                                                                    <action selector="stepperValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="exc-XA-1Yn"/>
                                                                 </connections>
                                                             </stepper>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wM1-kd-PYi">
@@ -730,7 +730,7 @@
                                                         </segments>
                                                         <color key="tintColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                         <connections>
-                                                            <action selector="autoLineCrossed:" destination="RmR-df-9YL" eventType="valueChanged" id="r5q-TE-mlV"/>
+                                                            <action selector="segmentedControlSelect:" destination="RmR-df-9YL" eventType="valueChanged" id="10d-Eh-t6i"/>
                                                         </connections>
                                                     </segmentedControl>
                                                 </subviews>
@@ -750,7 +750,7 @@
                                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="u7P-SE-NNx">
                                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="29"/>
                                                                 <connections>
-                                                                    <action selector="autoSwitchValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="BqW-tv-QYN"/>
+                                                                    <action selector="stepperValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="Bxp-aP-hU9"/>
                                                                 </connections>
                                                             </stepper>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YfX-Vf-4JF">
@@ -793,7 +793,7 @@
                                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="tjV-W9-3GG">
                                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="29"/>
                                                                 <connections>
-                                                                    <action selector="teleopScaleValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="hmq-or-dRC"/>
+                                                                    <action selector="stepperValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="hgP-p3-5Dz"/>
                                                                 </connections>
                                                             </stepper>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6g9-zA-wjj">
@@ -826,7 +826,7 @@
                                                                 </segments>
                                                                 <color key="tintColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                                 <connections>
-                                                                    <action selector="scaleLow:" destination="RmR-df-9YL" eventType="valueChanged" id="hc7-ik-oCh"/>
+                                                                    <action selector="segmentedControlSelect:" destination="RmR-df-9YL" eventType="valueChanged" id="ZvW-O7-1do"/>
                                                                 </connections>
                                                             </segmentedControl>
                                                         </subviews>
@@ -848,7 +848,7 @@
                                                                 </segments>
                                                                 <color key="tintColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                                 <connections>
-                                                                    <action selector="scaleMedium:" destination="RmR-df-9YL" eventType="valueChanged" id="cAq-fr-0i0"/>
+                                                                    <action selector="segmentedControlSelect:" destination="RmR-df-9YL" eventType="valueChanged" id="sc3-k5-YYo"/>
                                                                 </connections>
                                                             </segmentedControl>
                                                         </subviews>
@@ -870,7 +870,7 @@
                                                                 </segments>
                                                                 <color key="tintColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                                 <connections>
-                                                                    <action selector="scaleHigh:" destination="RmR-df-9YL" eventType="valueChanged" id="zHe-mM-64H"/>
+                                                                    <action selector="segmentedControlSelect:" destination="RmR-df-9YL" eventType="valueChanged" id="arL-2b-Yhr"/>
                                                                 </connections>
                                                             </segmentedControl>
                                                         </subviews>
@@ -895,7 +895,7 @@
                                                                     <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="5H9-cL-hfP">
                                                                         <rect key="frame" x="0.0" y="0.0" width="94" height="29"/>
                                                                         <connections>
-                                                                            <action selector="teleopSwitchValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="Ttj-na-NZf"/>
+                                                                            <action selector="stepperValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="Ey5-tL-B7d"/>
                                                                         </connections>
                                                                     </stepper>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmo-Cm-bTe">
@@ -923,7 +923,7 @@
                                                                     <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="5Ec-b2-pcU">
                                                                         <rect key="frame" x="0.0" y="0.0" width="94" height="29"/>
                                                                         <connections>
-                                                                            <action selector="teleopBlockExchangedValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="Dw4-zK-YLa"/>
+                                                                            <action selector="stepperValueChanged:" destination="RmR-df-9YL" eventType="valueChanged" id="SU2-PH-9IP"/>
                                                                         </connections>
                                                                     </stepper>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z15-Rr-0P9">
@@ -968,9 +968,6 @@
                                                                     <segment title="Yes"/>
                                                                 </segments>
                                                                 <color key="tintColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
-                                                                <connections>
-                                                                    <action selector="climbYNSelected:" destination="RmR-df-9YL" eventType="valueChanged" id="PeZ-4f-yCD"/>
-                                                                </connections>
                                                             </segmentedControl>
                                                         </subviews>
                                                     </stackView>


### PR DESCRIPTION
## Problem

The `DataEntryViewController` contains local variables for tracking the state of controls. However, these are not saved across runs of the app. The variables need to be stored in a data structure so it can be passed around the app and saved. 

## Solution
Extend the `Match` Protocol to create a `PowerMatch` class that stores all data associated with the `DataEntryViewController`. Additionally, the `Match` protocol adds functionality for exporting to CSV, exporting via Data Transfer, and managing multiple match instances with the `MatchStore`. 

## Issues Fixed
Resolves #5 

## Checks
- [x] App Builds and Runs
- [x] changes to the controls correctly update the `match` variable in the `DataEntryViewController`