### PR TITLE
Enable App File Sharing

### DIFF
--- a/PowerScout.xcodeproj/project.pbxproj
+++ b/PowerScout.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		C49884FB202D274F00B02555 /* PenaltyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49884FA202D274F00B02555 /* PenaltyViewController.swift */; };
 		C4988508202D9E1700B02555 /* ResultsMatchInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4988505202D9E1700B02555 /* ResultsMatchInfoViewController.swift */; };
 		C4988509202D9E1700B02555 /* ResultsScoringViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4988506202D9E1700B02555 /* ResultsScoringViewController.swift */; };
+		C4ABB5892032E762008CFBC1 /* SelectionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40BB94F2013E7050011DB45 /* SelectionButton.swift */; };
 		C4BF77A8202927C3006C34CC /* PowerMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77A7202927C3006C34CC /* PowerMatch.swift */; };
 		C4BF77AA20292817006C34CC /* PowerStartPositionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77A920292817006C34CC /* PowerStartPositionType.swift */; };
 		C4BF77AC2029284F006C34CC /* PowerEndClimbPositionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */; };
@@ -513,6 +514,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C4ABB5892032E762008CFBC1 /* SelectionButton.swift in Sources */,
 				C40BB9432013E6FE0011DB45 /* MasterViewController.swift in Sources */,
 				C47ABEAD2014441B007DAA6B /* DataEntryViewController.swift in Sources */,
 				C40BB9532013E7050011DB45 /* CustomContainerArrayView.swift in Sources */,

--- a/PowerScout/AppDelegate.swift
+++ b/PowerScout/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     var window: UIWindow?
     var orientationLock: UIInterfaceOrientationMask = .all
-    var matchStore = MatchStore(withMock: true)
+    var matchStore = MatchStore(withMock: false)
     var serviceStore = ServiceStore()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {

--- a/PowerScout/Info.plist
+++ b/PowerScout/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
This commit adds the ability for the app to share files between a computer via iTunes.

This commit also fixes a bug with the SelectionButton not being on the compile sources list. It also fixes a bug that enables mock data by default.

Issues: #27, #30, #31

## Problem

Exporting data works in the app, but the app cannot share the files via iTunes to a computer.

## Solution

Enable the file sharing option in the app through the Project Settings' info.plist. This also fixes bugs associated with the SelectionButton not being compiled and mock data being enabled by default.

## Issues Resolved
Resolve #27 
Resolve #30 
Resolve #31

## Checks
- [x] App builds and runs
- [x] Exporting match data completes and the csv file is available via iTunes file sharing
- [x] Mock data is not used by default
- [x] Showing the TeamInfo View displays the Selection Button appropriately.