### PR TITLE
Sync Results and Data Entry

### DIFF
--- a/PowerScout/DetailControllers/DataEntryViewController.swift
+++ b/PowerScout/DetailControllers/DataEntryViewController.swift
@@ -36,9 +36,6 @@ class DataEntryViewController: UIViewController, UIPickerViewDataSource, UIPicke
     var match:PowerMatch = PowerMatch()
     var matchStore:MatchStore!
     
-    let startPositions = ["Exchange", "Center", "NES"]
-    let climbConditions = ["No attempt", "Failure to climb", "No climb but helped another", "Climb by themselves", "Climb with help", "Climb helping another team"]
-    
     override func viewDidLoad() {
         startPositionPick.isHidden = true
         startPositionPick.dataSource = self
@@ -115,29 +112,29 @@ class DataEntryViewController: UIViewController, UIPickerViewDataSource, UIPicke
     
     func pickerView(_ pickerview: UIPickerView, numberOfRowsInComponent component: Int) -> Int{
         if pickerview == startPositionPick {
-            return startPositions.count
+            return PowerStartPositionType.all.count
         } else {
-            return climbConditions.count
+            return PowerEndClimbPositionType.all.count
         }
     }
     
     func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
         let attrs = [NSAttributedStringKey.font: UIFont.systemFont(ofSize: 22)]
         if pickerView == startPositionPick {
-            return NSAttributedString(string: startPositions[row], attributes: attrs)
+            return NSAttributedString(string: PowerStartPositionType.all[row].toString(), attributes: attrs)
         } else {
-            return NSAttributedString(string: climbConditions[row], attributes: attrs)
+            return NSAttributedString(string: PowerEndClimbPositionType.all[row].toString(), attributes: attrs)
         }
     }
     
     func pickerView(_ pickerview: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         if pickerview == startPositionPick{
-            positionButton.setTitle(startPositions[row], for: .normal)
+            positionButton.setTitle(PowerStartPositionType.all[row].toString(), for: .normal)
             startPositionPick.isHidden = true
             match.autoStartPos = PowerStartPositionType(rawValue: row+1)!
         }
         if pickerview == climbingConditionPick{
-            climbButton.setTitle(climbConditions[row], for: .normal)
+            climbButton.setTitle(PowerEndClimbPositionType.all[row].toString(), for: .normal)
             climbingConditionPick.isHidden = true
             match.endClimbCondition = PowerEndClimbPositionType(rawValue: row)!
         }

--- a/PowerScout/Models/Definitions/PowerEndClimbPositionType.swift
+++ b/PowerScout/Models/Definitions/PowerEndClimbPositionType.swift
@@ -10,15 +10,26 @@ import Foundation
 
 enum PowerEndClimbPositionType: Int {
     case none = 0
+    case failure
     case assistOther
     case soloClimb
     case assistedClimb
-    case soloClimbAssistOther
+    case climbAndAssistOther
     
     func toString() -> String {
-        return (self == .assistOther)          ? "Assisted Other"  :
-               (self == .soloClimb)            ? "Solo Climb"      :
-               (self == .assistedClimb)        ? "Climb with Assistance" :
-               (self == .soloClimbAssistOther) ? "Climb and Assisted Other" : "None";
+        return (self == .failure)              ? "Failure to Climb" :
+               (self == .assistOther)          ? "No climb, but helped another"   :
+               (self == .soloClimb)            ? "Climb by themselves"       :
+               (self == .assistedClimb)        ? "Climb with help" :
+               (self == .climbAndAssistOther)  ? "Climb, helping another team" : "None";
     }
+    
+    static let all:[PowerEndClimbPositionType] = [
+        .none,
+        .failure,
+        .assistOther,
+        .soloClimb,
+        .assistedClimb,
+        .climbAndAssistOther
+    ]
 }

--- a/PowerScout/Models/Definitions/PowerStartPositionType.swift
+++ b/PowerScout/Models/Definitions/PowerStartPositionType.swift
@@ -12,11 +12,17 @@ enum PowerStartPositionType:Int {
     case none = 0
     case exchange
     case center
-    case nonExchange
+    case nes
     
     func toString() -> String {
         return (self == .exchange)    ? "Exchange"        :
                (self == .center)      ? "Center"          :
-               (self == .nonExchange) ? "Not at Exchange" : "None";
+               (self == .nes) ? "NES" : "None";
     }
+    
+    static let all:[PowerStartPositionType] = [
+        .exchange,
+        .center,
+        .nes
+    ]
 }

--- a/PowerScout/Models/MatchStore.swift
+++ b/PowerScout/Models/MatchStore.swift
@@ -142,7 +142,7 @@ class MatchStore {
         
         let csvDataSave = writeCSVFile(withType: type)
         
-        return (matchDataSave ? 1 : 0) + (queueDataSave ? 2 : 0) + (csvDataSave ? 4 : 0)
+        return (matchDataSave ? 0 : 1) + (queueDataSave ? 0 : 2) + (csvDataSave ? 0 : 4)
     }
     
     func saveMatchQueueData() -> Bool {


### PR DESCRIPTION
## Problem

The string descriptions of the values during data entry and in the match summary are not the same

## Solution

Move the string description to a central location and use that as the source for both views

## Issued Fixed
Resolve #39 

## Checks 
- [x] App Builds and runs
- [x] Any description of the Starting Position and Climb Position values match on both views.