### PR TITLE
Fix Bluetooth Match Transfer Import

### DIFF
--- a/PowerScout.xcodeproj/project.pbxproj
+++ b/PowerScout.xcodeproj/project.pbxproj
@@ -974,7 +974,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = J4JEUUZ98V;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = PowerScout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -991,7 +991,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = J4JEUUZ98V;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = PowerScout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/PowerScout/MasterControllers/DataTransferViewController.swift
+++ b/PowerScout/MasterControllers/DataTransferViewController.swift
@@ -310,7 +310,19 @@ class DataTransferViewController: UIViewController, ServiceStoreDelegate {
         if let jsonData = json as? [Dictionary<String, AnyObject>] {
             var matches = [Match]();
             for matchData in jsonData {
-                matches.append(MatchImpl(withPList: matchData))
+                guard let matchTypeName = matchData["matchType"] as? String  else {
+                    print("WARNING: Match did not include match Type key! Defaulting to MatchImpl!")
+                    matches.append(MatchImpl(withPList: matchData))
+                    continue
+                }
+                
+                guard let matchType = NSClassFromString(matchTypeName) as? Match.Type else {
+                    print("WARNING: Invalid MatchType was given (\(matchTypeName)! Defaulting to MatchImpl!)")
+                    matches.append(MatchImpl(withPList: matchData))
+                    continue
+                }
+                
+                matches.append(matchType.init(withPList: matchData))
             }
             
             print("Matches Count: \(matches.count)")


### PR DESCRIPTION
## Problem

Matches that were imported through Bluetooth Transfers used the default `MatchImpl` base class to initialize the data. While this does set some data entries correctly, the `MatchImpl` class cannot initialize specific values of its subclasses. This problem was resolved in #26 for Match Initialization, but the same process was not included for Bluetooth file transfer.

## Solution

Use the "matchType" key in the transfer data to tell what type of Match this encoded data should be. If not type is provided, or it is invalid, the default `MatchImpl` will be used. However if a valid match type is provided (which is the case for `PowerMatch` objects). The correct initializer will be called. This will correctly get the `csvMatch` data that is used during the Match export to save the data.

## Issues Fixed
Resolve #53 

## Checks
- [x] App Builds and Runs
- [x] When Transferring Data
   - [x] Before the transfer, all data exports
   - [x] After the transfer, all data (with new transferred data) exports correctly