### PR TITLE
Add Match and Team Number to Data Entry Title

### DIFF
--- a/PowerScout/DetailControllers/DataEntryViewController.swift
+++ b/PowerScout/DetailControllers/DataEntryViewController.swift
@@ -80,6 +80,8 @@ class DataEntryViewController: UIViewController, UIPickerViewDataSource, UIPicke
         readyToMoveOn()
         
         match = matchStore.currentMatch as? PowerMatch ?? match
+        
+        self.navigationItem.title = "Match: \(match.matchNumber) Team: \(match.teamNumber)"
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
## Problem

The title for the Data Entry view only displayed "Data Entry" which did not include any information about the team or match.

## Solution
Change the title to include the Match and Team numbers. The new titles looks like this:
![simulator screen shot - ipad air - 2018-02-19 at 01 26 20](https://user-images.githubusercontent.com/2002470/36366627-8ffd5122-1514-11e8-9c81-52baf89c3103.png)

## Issues Fixed
Resolve #51 

## Checks
- [x] App builds and runs
- [x] Title for Data Entry matches the correct team and match numbers.
