### PR TITLE
Add Segue Back to Initial Detail Controller

### DIFF
--- a/PowerScout/MasterControllers/MasterViewController.swift
+++ b/PowerScout/MasterControllers/MasterViewController.swift
@@ -110,7 +110,7 @@ class MasterViewController: UITableViewController {
     }
     
     func clearMatchData(_ type:Int) {
-        let clearAllMatches = "Are you sure you want to clear all Match Data? Doing so will also permanently delete match data!"
+        let clearAllMatches = "Are you sure you want to clear all Match Data? Doing so will also permanently delete match data when data is exported next!"
         let ac = UIAlertController(title: "Clear Data", message: clearAllMatches, preferredStyle: .alert)
         
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
@@ -120,7 +120,9 @@ class MasterViewController: UITableViewController {
             hud.label.text = "Clearing Data..."
             DispatchQueue.global(qos: DispatchQoS.QoSClass.userInitiated).async(execute: {
                 self.matchStore.clearMatchData(type)
+                self.selectedMatch = nil
                 DispatchQueue.main.async(execute: {
+                    self.performSegue(withIdentifier: "SegueToInitialView", sender: self)
                     let hud = MBProgressHUD(for: self.navigationController!.view)
                     let imageView = UIImageView(image: UIImage(named: "Checkmark"))
                     hud?.customView = imageView

--- a/PowerScout/MasterControllers/MasterViewController.swift
+++ b/PowerScout/MasterControllers/MasterViewController.swift
@@ -250,9 +250,17 @@ class MasterViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
+            let match = matchStore.removeMatchAtIndex(indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
             
+            if let mMatch = match as? MatchImpl, let sMatch = selectedMatch as? MatchImpl {
+                if mMatch == sMatch {
+                    self.performSegue(withIdentifier: "SegueToInitialView", sender: self)
+                    selectedMatch = nil
+                }
+            }
             _ = matchStore.saveChanges(withMatchType: PowerMatch.self)
+            self.tableView.reloadSections(IndexSet(integer: indexPath.section), with: .none)
         }
     }
 

--- a/PowerScout/MasterControllers/MasterViewController.swift
+++ b/PowerScout/MasterControllers/MasterViewController.swift
@@ -58,11 +58,6 @@ class MasterViewController: UITableViewController {
                 }
             }
             segue.destination.popoverPresentationController!.delegate = self
-        } else if segue.identifier == "segueToMatchQueue" {
-            if let indexPath = self.tableView.indexPathForSelectedRow {
-                self.matchStore.createMatchFromQueueIndex(indexPath.row, withType: PowerMatch.self, onComplete: nil)
-                segue.destination.popoverPresentationController!.delegate = self
-            }
         } else if segue.identifier == "SegueToTransfer" {
             if let vc = segue.destination as? DataTransferViewController {
                 vc.matchStore = matchStore
@@ -99,19 +94,11 @@ class MasterViewController: UITableViewController {
     
     func handleClear(_ sender:UIBarButtonItem) {
         let ac = UIAlertController(title: "Clear Matches", message: "", preferredStyle: .actionSheet)
-        
-        let clearMatchQueue = UIAlertAction(title: "Clear Match Queue", style: .destructive, handler: {(action) in
-            self.clearMatchData(1)
-        })
-        let clearCompletedMatches = UIAlertAction(title: "Clear Completed Matches", style: .destructive, handler: {(action) in
-            self.clearMatchData(2)
-        })
+
         let clearAllMatches = UIAlertAction(title: "Clear All Matches", style: .destructive, handler: {(action) in
             self.clearMatchData(3)
         })
-        
-        ac.addAction(clearMatchQueue)
-        ac.addAction(clearCompletedMatches)
+
         ac.addAction(clearAllMatches)
         
         ac.popoverPresentationController?.barButtonItem = sender
@@ -122,10 +109,8 @@ class MasterViewController: UITableViewController {
     }
     
     func clearMatchData(_ type:Int) {
-        let clearMatchQueue = "Are you sure you want to clear Match Queue Data? You will have to rebuild a list from the Tools view to get a new queue of matches"
-        let clearCompletedMatches = "Are you sure you want to clear completed matches? Doing so will permanently delete match data the next time you export all match data!"
-        let clearAllMatches = "Are you sure you want to clear all Match Data? You will have to rebuild a list from the Tools view to get a new queue of matches.  Doing so will also permanently delete match data the next time you export all match data!"
-        let ac = UIAlertController(title: "Clear Data", message: (type == 1) ? clearMatchQueue : (type == 2) ? clearCompletedMatches : clearAllMatches, preferredStyle: .alert)
+        let clearAllMatches = "Are you sure you want to clear all Match Data? Doing so will also permanently delete match data!"
+        let ac = UIAlertController(title: "Clear Data", message: clearAllMatches, preferredStyle: .alert)
         
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         let continueAction = UIAlertAction(title: "Continue", style: .destructive, handler: {(action) in
@@ -231,39 +216,29 @@ class MasterViewController: UITableViewController {
     // MARK: - Table View
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return 1
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return section == 0 ? matchStore.matchesToScout.count > 0 ? "Matches Queued for Scouting" : nil :
-                              matchStore.allMatches.count     > 0 ? "Completed Matches"           : nil
+        return matchStore.allMatches.count > 0 ? "Completed Matches"           : nil
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return section == 0 ? matchStore.matchesToScout.count : matchStore.allMatches.count
+        return matchStore.allMatches.count
     }
     
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return section == 0 ? matchStore.matchesToScout.count > 0 ? "\(matchStore.matchesToScout.count) Match(es)" : nil :
-                              matchStore.allMatches.count     > 0 ? "\(matchStore.allMatches.count) Match(es)"     : nil
+        return matchStore.allMatches.count > 0 ? "\(matchStore.allMatches.count) Match(es)"     : nil
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "MatchCell", for: indexPath) as! MatchCell
 
-        if indexPath.section == 0 {
-            let match = matchStore.matchesToScout[indexPath.row]
-            cell.matchNumber.text = "\(match.matchNumber)"
-            cell.teamNumber.text = "\(match.teamNumber)"
-            
-            cell.accessoryType = .none;
-        } else {
-            let match = matchStore.allMatches[indexPath.row]
-            cell.matchNumber.text = "\(match.matchNumber)"
-            cell.teamNumber.text = "\(match.teamNumber)"
-            
-            cell.accessoryType = ((match.isCompleted & 32) != 32) ? .checkmark : .none
-        }
+        let match = matchStore.allMatches[indexPath.row]
+        cell.matchNumber.text = "\(match.matchNumber)"
+        cell.teamNumber.text = "\(match.teamNumber)"
+        
+        cell.accessoryType = ((match.isCompleted & 32) != 32) ? .checkmark : .none
 
         return cell
     }
@@ -274,11 +249,6 @@ class MasterViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            if indexPath.section == 0 {
-                matchStore.removeMatchQueueAtIndex(indexPath.row)
-            } else {
-                matchStore.removeMatchAtIndex(indexPath.row)
-            }
             tableView.deleteRows(at: [indexPath], with: .fade)
             
             _ = matchStore.saveChanges(withMatchType: PowerMatch.self)
@@ -286,11 +256,7 @@ class MasterViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if indexPath.section == 0 {
-            performSegue(withIdentifier: "segueToMatchQueue", sender: self)
-        } else {
-            performSegue(withIdentifier: "showMatchSummary", sender: self)
-        }
+        performSegue(withIdentifier: "showMatchSummary", sender: self)
     }
 }
 

--- a/PowerScout/MasterControllers/MasterViewController.swift
+++ b/PowerScout/MasterControllers/MasterViewController.swift
@@ -14,6 +14,7 @@ class MasterViewController: UITableViewController {
     @IBOutlet var clearExportButton:UIBarButtonItem!
     
     var matchStore:MatchStore!
+    var selectedMatch:Match?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -256,6 +257,7 @@ class MasterViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        self.selectedMatch = matchStore.allMatches[indexPath.row]
         performSegue(withIdentifier: "showMatchSummary", sender: self)
     }
 }

--- a/PowerScout/Models/MatchStore.swift
+++ b/PowerScout/Models/MatchStore.swift
@@ -259,9 +259,9 @@ class MatchStore {
         matchesToScout.remove(at: index)
     }
     
-    func removeMatchAtIndex(_ index:Int) {
-        guard 0..<allMatches.count ~= index else { return }
-        allMatches.remove(at: index)
+    func removeMatchAtIndex(_ index:Int) -> Match? {
+        guard 0..<allMatches.count ~= index else { return nil }
+        return allMatches.remove(at: index)
     }
     
     func removeMatch(_ thisMatch:Match) {

--- a/PowerScout/Storyboards/Base.lproj/Main.storyboard
+++ b/PowerScout/Storyboards/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
                         <viewControllerLayoutGuide type="bottom" id="FWo-DJ-kwW"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="rJz-u8-i1b">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="704"/>
+                        <rect key="frame" x="0.0" y="0.0" width="703.5" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hox-Cg-h28">
@@ -128,11 +128,11 @@
         <!--Navigation Controller-->
         <scene sceneID="af2-Wa-WPG">
             <objects>
-                <navigationController id="2CT-vx-lE6" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="InitialNavController" id="2CT-vx-lE6" sceneMemberID="viewController">
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <splitViewDetailSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <navigationBar key="navigationBar" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translucent="NO" id="ylH-tt-ah3">
-                        <rect key="frame" x="0.0" y="20" width="1024" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="703.5" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>

--- a/PowerScout/Storyboards/Base.lproj/MasterViews.storyboard
+++ b/PowerScout/Storyboards/Base.lproj/MasterViews.storyboard
@@ -255,6 +255,7 @@
                             <popoverArrowDirection key="popoverArrowDirection" up="YES" down="YES" left="YES" right="YES"/>
                         </segue>
                         <segue destination="kJb-XC-gky" kind="showDetail" identifier="segueToRecentMatchResults" id="U1d-ME-dn0"/>
+                        <segue destination="Uof-tL-JLB" kind="showDetail" identifier="SegueToInitialView" id="PoB-KY-xo7"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0ic-uc-kAe" sceneMemberID="firstResponder"/>
@@ -267,7 +268,15 @@
                 <viewControllerPlaceholder storyboardIdentifier="MatchSummaryNavController" storyboardName="Results" referencedIdentifier="MatchSummaryNavController" id="kJb-XC-gky" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="trn-na-Udz" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2246" y="-630"/>
+            <point key="canvasLocation" x="1870" y="-677"/>
+        </scene>
+        <!--InitialNavController-->
+        <scene sceneID="e4i-XE-RUS">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Main" referencedIdentifier="InitialNavController" id="Uof-tL-JLB" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2Yu-7e-6rx" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1846" y="-830"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="JTd-kD-85I">
@@ -1008,7 +1017,7 @@
         <segue reference="cYe-sG-gmv"/>
         <segue reference="QSe-ic-oVb"/>
         <segue reference="U1d-ME-dn0"/>
-        <segue reference="WbF-9A-5UB"/>
+        <segue reference="FE0-HP-URS"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.99810189008712769" green="0.41443628072738647" blue="0.0016002511838451028" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>


### PR DESCRIPTION
## Problem

1. When a Match is selected, the results summary is shown. When this match is then deleted, the results view is still shown. 
2. The master view controller is complex due to managing two sections of the table view (matches to scout and completed matches). Since the matches to scout has been removed, there's no need for this complexity

## Solution
1. Add a Segue to the initial view controller and perform the segue when the selected match is also the match viewed in the Results summary
2. Remove any code associated with the matches to scout references.

## Issues Fixed 
Resolve #50 
Resolve #56 

## Checks
- [x] App builds and runs
- [x] When a match is selected to display results, deleting the match individually will segue back to the initial view
- [x] When a match is selected to display results, deleting the match via the bulk clear option will segue back to the initial view
- [x] When a match is NOT selected to display results, deleting the match individually will segue back to the initial view.