### PR TITLE
Change Climb Condition Label

### DIFF
--- a/PowerScout/Models/Definitions/PowerEndClimbPositionType.swift
+++ b/PowerScout/Models/Definitions/PowerEndClimbPositionType.swift
@@ -21,7 +21,7 @@ enum PowerEndClimbPositionType: Int {
                (self == .assistOther)          ? "No climb - but helped another"   :
                (self == .soloClimb)            ? "Climb by themselves"       :
                (self == .assistedClimb)        ? "Climb with help" :
-               (self == .climbAndAssistOther)  ? "Climb - helping another team" : "None";
+               (self == .climbAndAssistOther)  ? "Climb - helping another team" : "No Attempt";
     }
     
     static let all:[PowerEndClimbPositionType] = [


### PR DESCRIPTION
## Problem

The default climb condition was labelled as "None" when it should be "No Attempt"

## Solution

Change toString representation of the climb condition to be "No Attempt"

## Issues Fixed
Resolve #48

## Checks
- [x] App Builds and Runs
- [x] "No Attempt" is shown as the label in the Data Entry View
- [x] When No Attempt is selected and confirmed in a completed match, the Results view shows "No Attempt" as the label
- [x] When No Attempt is selected and confirmed in a completed match, the exported data shows "No Attempt" as the value
