### PR TITLE
Change Picker View Controls

### DIFF
--- a/PowerScout.xcodeproj/project.pbxproj
+++ b/PowerScout.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		C4988508202D9E1700B02555 /* ResultsMatchInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4988505202D9E1700B02555 /* ResultsMatchInfoViewController.swift */; };
 		C4988509202D9E1700B02555 /* ResultsScoringViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4988506202D9E1700B02555 /* ResultsScoringViewController.swift */; };
 		C4ABB5892032E762008CFBC1 /* SelectionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40BB94F2013E7050011DB45 /* SelectionButton.swift */; };
+		C4B0D9AB203BFB3400655CAB /* PickerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B0D9AA203BFB3400655CAB /* PickerTextField.swift */; };
+		C4B0D9AC203BFB3400655CAB /* PickerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B0D9AA203BFB3400655CAB /* PickerTextField.swift */; };
 		C4BF77A8202927C3006C34CC /* PowerMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77A7202927C3006C34CC /* PowerMatch.swift */; };
 		C4BF77AA20292817006C34CC /* PowerStartPositionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77A920292817006C34CC /* PowerStartPositionType.swift */; };
 		C4BF77AC2029284F006C34CC /* PowerEndClimbPositionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */; };
@@ -154,6 +156,7 @@
 		C481788920132531001EAF24 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C4988505202D9E1700B02555 /* ResultsMatchInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsMatchInfoViewController.swift; sourceTree = "<group>"; };
 		C4988506202D9E1700B02555 /* ResultsScoringViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsScoringViewController.swift; sourceTree = "<group>"; };
+		C4B0D9AA203BFB3400655CAB /* PickerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerTextField.swift; sourceTree = "<group>"; };
 		C4BF77A7202927C3006C34CC /* PowerMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerMatch.swift; sourceTree = "<group>"; };
 		C4BF77A920292817006C34CC /* PowerStartPositionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerStartPositionType.swift; sourceTree = "<group>"; };
 		C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerEndClimbPositionType.swift; sourceTree = "<group>"; };
@@ -239,6 +242,7 @@
 				C40BB94F2013E7050011DB45 /* SelectionButton.swift */,
 				C40BB9502013E7050011DB45 /* themeDefinitions.swift */,
 				C40BB9512013E7050011DB45 /* UINavigationController+Rotation.swift */,
+				C4B0D9AA203BFB3400655CAB /* PickerTextField.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -676,6 +680,7 @@
 			files = (
 				C46386D52035442400424EA3 /* RollingAverage.swift in Sources */,
 				C45A9BA72033CB21001C2AC3 /* MatchCell.swift in Sources */,
+				C4B0D9AC203BFB3400655CAB /* PickerTextField.swift in Sources */,
 				C45A9BA62033CAD5001C2AC3 /* AppUtility.swift in Sources */,
 				C45A9BA22033CAC3001C2AC3 /* SelectionButton.swift in Sources */,
 				C45A9BA32033CAC3001C2AC3 /* themeDefinitions.swift in Sources */,
@@ -720,6 +725,7 @@
 				C40BB9802013E7C60011DB45 /* MatchStore.swift in Sources */,
 				C40BB97A2013E7C60011DB45 /* SteamStartPositionType.swift in Sources */,
 				C40F316420230D44004EF250 /* NearbyDevicesTableViewController.swift in Sources */,
+				C4B0D9AB203BFB3400655CAB /* PickerTextField.swift in Sources */,
 				C40BB97B2013E7C60011DB45 /* Definitions.swift in Sources */,
 				C40BB9522013E7050011DB45 /* AppUtility.swift in Sources */,
 				C4BF77AC2029284F006C34CC /* PowerEndClimbPositionType.swift in Sources */,

--- a/PowerScout/Storyboards/Base.lproj/DataEntry.storyboard
+++ b/PowerScout/Storyboards/Base.lproj/DataEntry.storyboard
@@ -223,17 +223,17 @@
                                                 <color key="textColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Z2y-MW-TCq">
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Z2y-MW-TCq">
                                                 <rect key="frame" x="0.0" y="52" width="736" height="26.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Starting Position:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aek-7A-5eq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="309.5" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="364" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select Starting Position" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KY5-Rx-mz6" customClass="PickerTextField" customModule="PowerScout" customModuleProvider="target">
-                                                        <rect key="frame" x="317.5" y="-3.5" width="418.5" height="30"/>
+                                                        <rect key="frame" x="372" y="-3.5" width="364" height="30"/>
                                                         <nil key="textColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -496,17 +496,17 @@
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="K5t-U5-h5u">
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="K5t-U5-h5u">
                                                 <rect key="frame" x="0.0" y="221.5" width="736" height="26.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Climbing Attempt: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Wf-Kr-3aC">
-                                                        <rect key="frame" x="0.0" y="0.0" width="329" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="364" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select Climb Condition" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="alq-8w-2Cr" customClass="PickerTextField" customModule="PowerScout" customModuleProvider="target">
-                                                        <rect key="frame" x="337" y="-3.5" width="399" height="30"/>
+                                                        <rect key="frame" x="372" y="-3.5" width="364" height="30"/>
                                                         <nil key="textColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>

--- a/PowerScout/Storyboards/Base.lproj/DataEntry.storyboard
+++ b/PowerScout/Storyboards/Base.lproj/DataEntry.storyboard
@@ -212,10 +212,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="vrd-16-0Lb">
-                                <rect key="frame" x="16" y="16" width="736" height="733"/>
+                                <rect key="frame" x="16" y="16" width="736" height="632"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="dpf-5y-ITy" userLabel="Autonomous">
-                                        <rect key="frame" x="0.0" y="0.0" width="736" height="245"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="736" height="194.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Autonomous" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t1a-Gi-fNi">
                                                 <rect key="frame" x="0.0" y="0.0" width="736" height="42"/>
@@ -224,42 +224,24 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Z2y-MW-TCq">
-                                                <rect key="frame" x="0.0" y="52" width="736" height="77"/>
+                                                <rect key="frame" x="0.0" y="52" width="736" height="26.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Starting Position:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aek-7A-5eq">
-                                                        <rect key="frame" x="0.0" y="0.5" width="210" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="309.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="1Ea-jb-zxK">
-                                                        <rect key="frame" x="218" y="-7" width="518" height="84"/>
-                                                        <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rDa-xg-cDW">
-                                                                <rect key="frame" x="0.0" y="0.0" width="518" height="34"/>
-                                                                <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                                <state key="normal" title="Select Postion">
-                                                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                </state>
-                                                                <connections>
-                                                                    <action selector="positionSelect:" destination="RmR-df-9YL" eventType="touchUpInside" id="tLX-KC-yec"/>
-                                                                </connections>
-                                                            </button>
-                                                            <pickerView contentMode="scaleToFill" verticalHuggingPriority="240" verticalCompressionResistancePriority="740" translatesAutoresizingMaskIntoConstraints="NO" id="Olf-JV-OjY">
-                                                                <rect key="frame" x="0.0" y="34" width="518" height="50"/>
-                                                                <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <accessibility key="accessibilityConfiguration" label="Pick Starting Position"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="50" id="Yy3-0s-C59"/>
-                                                                </constraints>
-                                                            </pickerView>
-                                                        </subviews>
-                                                    </stackView>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select Starting Position" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KY5-Rx-mz6" customClass="PickerTextField" customModule="PowerScout" customModuleProvider="target">
+                                                        <rect key="frame" x="317.5" y="-3.5" width="418.5" height="30"/>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                    </textField>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fHF-7h-oy9">
-                                                <rect key="frame" x="0.0" y="139" width="736" height="29"/>
+                                                <rect key="frame" x="0.0" y="88.5" width="736" height="29"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cubes on Scale :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vfk-mv-x59">
                                                         <rect key="frame" x="0.0" y="0.0" width="437" height="29"/>
@@ -290,7 +272,7 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cXD-iC-Pvg">
-                                                <rect key="frame" x="0.0" y="178" width="736" height="28"/>
+                                                <rect key="frame" x="0.0" y="127.5" width="736" height="28"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Crossed Auto Line:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1KB-ju-rsx">
                                                         <rect key="frame" x="0.0" y="0.0" width="437" height="28"/>
@@ -312,7 +294,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kch-Ha-b7y">
-                                                <rect key="frame" x="0.0" y="216" width="736" height="29"/>
+                                                <rect key="frame" x="0.0" y="165.5" width="736" height="29"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cubes on Switch :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kMr-M3-PVO">
                                                         <rect key="frame" x="0.0" y="0.0" width="437" height="29"/>
@@ -346,7 +328,7 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="VI8-Xm-3B9" userLabel="Teleop">
-                                        <rect key="frame" x="0.0" y="270" width="736" height="298.5"/>
+                                        <rect key="frame" x="0.0" y="219.5" width="736" height="248"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Teleop" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QY4-Ci-bTL">
                                                 <rect key="frame" x="0.0" y="0.0" width="736" height="39.5"/>
@@ -515,43 +497,26 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="K5t-U5-h5u">
-                                                <rect key="frame" x="0.0" y="221.5" width="736" height="77"/>
+                                                <rect key="frame" x="0.0" y="221.5" width="736" height="26.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Climbing Attempt: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Wf-Kr-3aC">
-                                                        <rect key="frame" x="0.0" y="0.5" width="223" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="329" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="rb7-mr-9jT">
-                                                        <rect key="frame" x="231" y="-7" width="505" height="84"/>
-                                                        <subviews>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OYa-sP-zX7">
-                                                                <rect key="frame" x="0.0" y="0.0" width="505" height="34"/>
-                                                                <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                                                <state key="normal" title="Select Climbing Condition">
-                                                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                </state>
-                                                                <connections>
-                                                                    <action selector="climbCondSelect:" destination="RmR-df-9YL" eventType="touchUpInside" id="v9b-QM-8Kd"/>
-                                                                </connections>
-                                                            </button>
-                                                            <pickerView contentMode="scaleAspectFit" verticalHuggingPriority="240" verticalCompressionResistancePriority="760" translatesAutoresizingMaskIntoConstraints="NO" id="WEE-Xe-R7O">
-                                                                <rect key="frame" x="0.0" y="34" width="505" height="50"/>
-                                                                <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="50" id="XaQ-JH-SCY"/>
-                                                                </constraints>
-                                                            </pickerView>
-                                                        </subviews>
-                                                    </stackView>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select Climb Condition" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="alq-8w-2Cr" customClass="PickerTextField" customModule="PowerScout" customModuleProvider="target">
+                                                        <rect key="frame" x="337" y="-3.5" width="399" height="30"/>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                    </textField>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="8ck-Kb-Yn3" userLabel="Extra">
-                                        <rect key="frame" x="0.0" y="593.5" width="736" height="139.5"/>
+                                        <rect key="frame" x="0.0" y="492.5" width="736" height="139.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Final Details" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5pw-vn-dFn">
                                                 <rect key="frame" x="0.0" y="0.0" width="736" height="39.5"/>
@@ -681,14 +646,12 @@
                         <outlet property="autoLine" destination="PXL-oC-oAo" id="zep-Bz-Xst"/>
                         <outlet property="autoScale" destination="ssU-XW-a6d" id="gR0-Ao-ijX"/>
                         <outlet property="autoSwitch" destination="u7P-SE-NNx" id="6LP-NH-sol"/>
-                        <outlet property="climbButton" destination="OYa-sP-zX7" id="Vsj-gb-zT0"/>
-                        <outlet property="climbingConditionPick" destination="WEE-Xe-R7O" id="cdX-yk-B8A"/>
+                        <outlet property="climbTextField" destination="alq-8w-2Cr" id="QMf-RW-I79"/>
                         <outlet property="exchangedBlocks" destination="5Ec-b2-pcU" id="LLW-FU-S1F"/>
-                        <outlet property="positionButton" destination="rDa-xg-cDW" id="ksN-3N-gr6"/>
+                        <outlet property="positionTextField" destination="KY5-Rx-mz6" id="HTG-Y0-nTh"/>
                         <outlet property="scaleHigh" destination="neq-bo-XYO" id="NRW-le-ad6"/>
                         <outlet property="scaleLow" destination="FQb-5D-gr5" id="BYd-K0-s7H"/>
                         <outlet property="scaleMedium" destination="tbE-uX-FZi" id="FhI-EC-phe"/>
-                        <outlet property="startPositionPick" destination="Olf-JV-OjY" id="boD-SE-xw2"/>
                         <outlet property="teleAmmountScale" destination="6g9-zA-wjj" id="WOR-T0-BAP"/>
                         <outlet property="teleAmmountSwitch" destination="tmo-Cm-bTe" id="tLT-fE-dUn"/>
                         <outlet property="teleScale" destination="tjV-W9-3GG" id="TLH-at-4El"/>

--- a/PowerScout/Support/PickerTextField.swift
+++ b/PowerScout/Support/PickerTextField.swift
@@ -1,0 +1,25 @@
+//
+//  PickerTextField.swift
+//  PowerScout
+//
+//  Created by Srinivas Dhanwada on 2/20/18.
+//  Copyright © 2018 FRC Team 525. All rights reserved.
+//
+
+import UIKit
+
+class PickerTextField: UITextField {
+    
+    override func caretRect(for position: UITextPosition) -> CGRect {
+        return CGRect.zero
+    }
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}


### PR DESCRIPTION
## Problem

The Start Position and Climb Condition inputs in the data entry view utilize picker views that are hidden within the view hierarchy. This causes problem with the layout as the showing and hiding of the picker views occurs. 

## Solution

Instead of having the pickers views within the view hierarchy, they are now set as input views for the controls and appear similar to how a keyboard appears. There is also a Done button on the keyboard to hide the picker view if it was accidentally triggered. 

## Issues Fixed
Resolve #49 

## Checks
- [x] App Builds and Runs
- [x] Controls work as expected
- [x] Selected values for both picker views properly translate to an exported match
