### PR TITLE
Add Standardized Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+### Issue Description
+
+(a brief summary of your issue)
+
+### You Environment
+- App Version:
+- iOS Version:
+- Device Type: (ex. iPad 2, iPad Air, ...)
+> You can also include the model number by looking at: Settings > General > About
+
+### Steps to Reproduce
+- Include a list of steps that will reproduce your issue
+- Add a note if you can only reproduce the issue intermittently
+
+### Expected Behavior
+
+( A brief description of what you expect to happen)
+
+### Actual Behavior
+
+( A brief description of what is actually happening)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Problem
+
+(A summary of the problem with the current build)
+
+### Solution
+
+(A summary of the changes you made)
+(- This can be in list form
+- If you like)
+
+### Checks
+- [ ] App Builds and Runs (Simulation)
+  - List the simulator you tested and the iOS Version
+- [ ] App Builds and Runs (On Device)
+  - List the device you tested and the iOS Version
+- [ ] Add any other checks you did to confirm corrected behavior
+  - [ ] You can include sub items for detailed checks 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,11 @@
 (- This can be in list form
 - If you like)
 
+### Issues Fixed
+(Add a list of issues you are addressing here)
+> Issues can be references by their ID using #<id>. This creates an automatic link to issue page!
+> To automatically close the issue when this PR merges, use the format "Resolve #<id>".
+
 ### Checks
 - [ ] App Builds and Runs (Simulation)
   - List the simulator you tested and the iOS Version

--- a/PowerScout.xcodeproj/project.pbxproj
+++ b/PowerScout.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		C4BF77AC2029284F006C34CC /* PowerEndClimbPositionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */; };
 		C4BF77AE202AD20B006C34CC /* FinalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77AD202AD20B006C34CC /* FinalViewController.swift */; };
 		C4BF77B0202AD210006C34CC /* TeamInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BF77AF202AD210006C34CC /* TeamInfoViewController.swift */; };
+		C4FC71D020499F80000C3BEE /* InitialDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FC71CF20499F80000C3BEE /* InitialDetailViewController.swift */; };
 		C4FC801A201EF3DE0073D087 /* DebugDataTransferViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FC8019201EF3DE0073D087 /* DebugDataTransferViewController.swift */; };
 		C8960BF2C27029302CEC1C9B /* Pods_PowerScoutDebugging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FE63DE85D261E81D3C17622 /* Pods_PowerScoutDebugging.framework */; };
 /* End PBXBuildFile section */
@@ -162,6 +163,7 @@
 		C4BF77AB2029284F006C34CC /* PowerEndClimbPositionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerEndClimbPositionType.swift; sourceTree = "<group>"; };
 		C4BF77AD202AD20B006C34CC /* FinalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FinalViewController.swift; sourceTree = "<group>"; };
 		C4BF77AF202AD210006C34CC /* TeamInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamInfoViewController.swift; sourceTree = "<group>"; };
+		C4FC71CF20499F80000C3BEE /* InitialDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialDetailViewController.swift; sourceTree = "<group>"; };
 		C4FC8019201EF3DE0073D087 /* DebugDataTransferViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDataTransferViewController.swift; sourceTree = "<group>"; };
 		E2D24E694F4F9F710E5EE5C5 /* Pods_PowerScout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PowerScout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA393782602B7CFAE85CDBEE /* Pods-PowerScout.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PowerScout.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PowerScout/Pods-PowerScout.debug.xcconfig"; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 				C4BF77AF202AD210006C34CC /* TeamInfoViewController.swift */,
 				C4BF77AD202AD20B006C34CC /* FinalViewController.swift */,
 				C47ABEAC2014441B007DAA6B /* DataEntryViewController.swift */,
+				C4FC71CF20499F80000C3BEE /* InitialDetailViewController.swift */,
 			);
 			path = DetailControllers;
 			sourceTree = "<group>";
@@ -742,6 +745,7 @@
 				C40BB97E2013E7C60011DB45 /* Match.swift in Sources */,
 				C4757C192016D40100C90984 /* ServiceStoreDelegate.swift in Sources */,
 				C40F316320230D44004EF250 /* DataSelectionViewController.swift in Sources */,
+				C4FC71D020499F80000C3BEE /* InitialDetailViewController.swift in Sources */,
 				C4BF77AE202AD20B006C34CC /* FinalViewController.swift in Sources */,
 				C481786620132531001EAF24 /* AppDelegate.swift in Sources */,
 				C40BB97F2013E7C60011DB45 /* MatchEncodingHelper.swift in Sources */,

--- a/PowerScout/DetailControllers/InitialDetailViewController.swift
+++ b/PowerScout/DetailControllers/InitialDetailViewController.swift
@@ -1,0 +1,46 @@
+//
+//  InitialDetailViewController.swift
+//  PowerScout
+//
+//  Created by Srinivas Dhanwada on 3/2/18.
+//  Copyright © 2018 FRC Team 525. All rights reserved.
+//
+
+import UIKit
+
+class InitialDetailViewController: UIViewController {
+    
+    @IBOutlet weak var versionLabel: UILabel!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as! String
+        
+        versionLabel.text = "Version: \(version).\(build)"
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/PowerScout/Info.plist
+++ b/PowerScout/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothPeripheralUsageDescription</key>

--- a/PowerScout/Storyboards/Base.lproj/Main.storyboard
+++ b/PowerScout/Storyboards/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--Detail-->
         <scene sceneID="YXq-Nr-Li6">
             <objects>
-                <viewController title="Detail" id="9xi-cg-hXL" sceneMemberID="viewController">
+                <viewController title="Detail" id="9xi-cg-hXL" customClass="InitialDetailViewController" customModule="PowerScout" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="ODt-2m-ly1"/>
                         <viewControllerLayoutGuide type="bottom" id="FWo-DJ-kwW"/>
@@ -96,16 +96,28 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version: ??" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aVO-kf-OGL">
+                                <rect key="frame" x="20.5" y="664" width="662.5" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="hox-Cg-h28" firstAttribute="top" secondItem="ODt-2m-ly1" secondAttribute="bottom" constant="20" id="39D-W1-WA9"/>
                             <constraint firstItem="hox-Cg-h28" firstAttribute="centerX" secondItem="rJz-u8-i1b" secondAttribute="centerX" id="CFm-Fq-vZj"/>
+                            <constraint firstItem="FWo-DJ-kwW" firstAttribute="top" secondItem="aVO-kf-OGL" secondAttribute="bottom" constant="20" id="IZh-qZ-NUz"/>
+                            <constraint firstItem="aVO-kf-OGL" firstAttribute="centerX" secondItem="rJz-u8-i1b" secondAttribute="centerX" id="bjb-bn-uPh"/>
                             <constraint firstAttribute="leadingMargin" secondItem="hox-Cg-h28" secondAttribute="leading" id="jjw-Mi-Klk"/>
+                            <constraint firstAttribute="trailing" secondItem="aVO-kf-OGL" secondAttribute="trailing" constant="20.5" id="wcd-5x-gkq"/>
                         </constraints>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" title="Power Up Scout" id="QrQ-0h-YHz"/>
+                    <connections>
+                        <outlet property="versionLabel" destination="aVO-kf-OGL" id="qph-5d-a10"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="udx-EE-KWP" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
### Problem

There is no standard format or list of required information when submitting an issue. We also don't have an easy way to see the version number of the app.

### Solution
- Add a Version Number Label to the Initial Detail Controller when the app starts
- Add Issue and PR templates that include an organized format of information we expect

### Issues Fixed
Resolve #69 
Resolve #70 

### Checks
- [x] App Builds and Runs (Simulator)
  - Tested on iPad 2 (iOS 9.3) and iPad Air 2 (iOS 11.2) Simulators
- [x] App Builds and Runs (Device)
  - Tested on iPad 2 (iOS 9.3)
- [x] Correct Version is displayed
