### PR TITLE
Add Initial Version Bump Scripts

### DIFF
--- a/scripts/git_version_bump.sh
+++ b/scripts/git_version_bump.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 {PATCH|MINOR|MAJOR}"
+  exit 1
+fi
+
+update_type="$1"
+root_dir="$(git rev-parse --show-toplevel)"
+plist="$root_dir/PowerScout/Info.plist"
+latest_tag="$(git describe --tags --abbrev=0)"
+
+majornum=`echo "$latest_tag" | awk -F "." '{print $1}'`
+minornum=`echo "$latest_tag" | awk -F "." '{print $2}'`
+patchnum=`echo "$latest_tag" | awk -F "." '{print $3}'`
+new_majornum="$majornum"
+new_minornum="$minornum"
+new_patchnum="$patchnum"
+
+case "$update_type" in
+  MAJOR)
+    new_patchnum=0
+    new_minornum=0
+    new_majornum=$(($majornum + 1))
+    ;;
+  MINOR)
+    new_patchnum=0
+    new_minornum=$(($minornum + 1))
+    ;;
+  PATCH)
+    new_patchnum=$(($patchnum + 1))
+    ;;
+  *)
+    echo "Invalid Update Type given! Valie types: PATCH, MINOR, MAJOR"
+    exit 2
+esac
+
+echo "Tagging: $majornum.$minornum.$patchnum ~> $new_majornum.$new_minornum.$new_patchnum..."
+
+source "$root_dir"/scripts/xcode_version_bump.sh "$plist" "$update_type"
+$(git add .)
+$(git commit -q --author="Version Bump Bot <>" -m "$update_type Version Bump ~> $new_majornum.$new_minornum.$new_patchnum")
+$(git tag "$new_majornum"."$new_minornum"."$new_patchnum")
+
+echo "Tag Done!"
+

--- a/scripts/git_version_bump.sh
+++ b/scripts/git_version_bump.sh
@@ -9,6 +9,7 @@ update_type="$1"
 root_dir="$(git rev-parse --show-toplevel)"
 plist="$root_dir/PowerScout/Info.plist"
 latest_tag="$(git describe --tags --abbrev=0)"
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 majornum=`echo "$latest_tag" | awk -F "." '{print $1}'`
 minornum=`echo "$latest_tag" | awk -F "." '{print $2}'`
@@ -16,6 +17,13 @@ patchnum=`echo "$latest_tag" | awk -F "." '{print $3}'`
 new_majornum="$majornum"
 new_minornum="$minornum"
 new_patchnum="$patchnum"
+
+if [[ "$current_branch" != "master" ]]; then
+	echo "Current Branch: $current_branch"
+	echo "You must be on the master branch to run this script!"
+	echo "To switch branches, type \`git checkout master\`"
+	exit 3
+fi
 
 case "$update_type" in
   MAJOR)

--- a/scripts/version_bump.sh
+++ b/scripts/version_bump.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]; then
+  echo "usage: $0 <plist-file> {PATCH|MINOR|MAJOR}"
+  exit 1
+fi
+
+plist="$1"
+update_type="$2"
+current_dir="$(dirname "$plist")"
+
+buildnum=$(/usr/libexec/Plistbuddy -c "Print CFBundleVersion" "$plist")
+if [ -z "$buildnum" ]; then
+  echo "No build number found! Could not perform version bump"
+  exit 2
+fi
+versionnum=$(/usr/libexec/Plistbuddy -c "Print CFBundleShortVersionString" "$plist")
+if [ -z "$versionnum" ]; then
+  echo "No version string found! Could not perform version bump"
+  exit 3
+fi
+majornum=`echo "$versionnum" | awk -F "." '{print $1}'`
+minornum=`echo "$versionnum" | awk -F "." '{print $2}'`
+new_buildnum="$buildnum"
+new_majornum="$majornum"
+new_minornum="$minornum"
+
+case "$update_type" in
+  MAJOR)
+    new_buildnum=0
+    new_minornum=0
+    new_majornum=$(($majornum + 1))
+    ;;
+  MINOR)
+    new_buildnum=0
+    new_minornum=$(($minornum + 1))
+    ;;
+  PATCH)
+    new_buildnum=$(($buildnum + 1))
+    ;;
+  *)
+    echo "Invalid Update Type given! Valid types: PATCH, MINOR, MAJOR"
+    exit 4
+    ;;
+esac
+
+echo "Performing Bump: $majornum.$minornum.$buildnum ~> $new_majornum.$new_minornum.$new_buildnum..."
+
+/usr/libexec/Plistbuddy -c "Set CFBundleVersion $new_buildnum" "$plist"
+/usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString $new_majornum.$new_minornum" "$plist"
+
+echo "Version Bump Done!"
+

--- a/scripts/xcode_version_bump.sh
+++ b/scripts/xcode_version_bump.sh
@@ -44,7 +44,7 @@ case "$update_type" in
     ;;
 esac
 
-echo "Performing Bump: $majornum.$minornum.$buildnum ~> $new_majornum.$new_minornum.$new_buildnum..."
+echo "Performing Xcode Bump: $majornum.$minornum.$buildnum ~> $new_majornum.$new_minornum.$new_buildnum..."
 
 /usr/libexec/Plistbuddy -c "Set CFBundleVersion $new_buildnum" "$plist"
 /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString $new_majornum.$new_minornum" "$plist"


### PR DESCRIPTION
### Problem

Now that we have completed the initial version of the app, we have to manage the version number of the app and sync it to the version we are tagging. These changes must conform to [semantic versioning](https://semver.org) so a consumer can tell the type of changes to expect when changing versions.

### Solution
- Create an initial version bump script that will change the Xcode app version automatically based on a given update type (PATCH, MINOR, MAJOR)
- Create an initial version bump script that calls the previous script, commits the changes, and tags the latest commit
  - This must be done on the master branch! The git version bump script checks this.

See this [comment](https://github.com/Swartdogs/PowerScout/issues/73#issuecomment-372895086) for steps to use the version bump scripts.

### Issues Fixed
Resolve #73 

### Checks
- [x] App Builds and Runs (Simulation)
  - iPad 2 iOS 9.3, iPad Air 2 iOS 11.2
- [x] App Builds and Runs (On Device)
  - iPad 2 iOS 9.3, iPhone X iOS 11.2
- [x] Version bump script works only on master branch
- [x] Script creates the correct version changes and correctly commits them to the master branch